### PR TITLE
Reset state of SinglyLinkedList after accesing a key on HashTable

### DIFF
--- a/lib/data-structures/hash-table/hash_table.rb
+++ b/lib/data-structures/hash-table/hash_table.rb
@@ -19,8 +19,13 @@ class HashTable
     if list = @map[self.hash_func(key)]
       current_node = list.current_node
       until list.current_node.nil?
-        return list.current_node.value.value if list.current_node.value.key == key
-        list.next_node
+        if list.current_node.value.key == key
+          value = list.current_node.value.value
+          list.reset!
+          return value
+        else
+          list.next_node
+        end
       end
     end
   end

--- a/spec/data-structures/hash-table/hash_table_spec.rb
+++ b/spec/data-structures/hash-table/hash_table_spec.rb
@@ -14,6 +14,7 @@ describe HashTable do
       table["a"] = "a value"
       table["A"] = "A value"
       expect(table[key]).to eq value
+      expect(table["a"]).to eq "a value"
     end
   end
   context "#[]" do


### PR DESCRIPTION
- HashTable#[] was maintaining current_node state of its list, which
  caused the next access to the same hashed_key to return nil
- Added test for it
- Couldn't keep a one liner.. My ruby skillz are kinda fading away :P
