### PR TITLE
Add string buffer data structure.

### DIFF
--- a/lib/data-structures/string-buffer/string.rb
+++ b/lib/data-structures/string-buffer/string.rb
@@ -1,0 +1,12 @@
+require_relative 'string_buffer'
+class String
+
+  def self.join_words words
+    sentence = StringBuffer.new
+    words.each do |word|
+      sentence.append word
+    end
+    sentence.to_s
+  end
+
+end

--- a/lib/data-structures/string-buffer/string_buffer.rb
+++ b/lib/data-structures/string-buffer/string_buffer.rb
@@ -1,0 +1,22 @@
+class StringBuffer
+
+  attr_accessor :buffer
+  def initialize
+    @buffer = []
+  end
+
+  def append word
+    buffer.push word
+  end
+
+  def to_s
+    raise EmptyBufferError.new("buffer is empty") if buffer.empty?
+    sentence = ""
+    buffer.each do |word|
+      sentence += word
+    end
+    sentence
+  end
+end
+
+class EmptyBufferError < StandardError; end

--- a/spec/data-structures/string-buffer/string_buffer_spec.rb
+++ b/spec/data-structures/string-buffer/string_buffer_spec.rb
@@ -1,0 +1,44 @@
+require_relative '../../spec_helper'
+describe StringBuffer do
+
+  let(:my_buffer) { StringBuffer.new }
+  let(:my_word) { 'test' }
+  describe '#initialize' do
+    it 'makes a StringBuffer' do
+      expect(my_buffer).to be_an_instance_of StringBuffer
+    end
+
+    it 'creates an empty buffer array' do
+      expect(my_buffer.buffer).to be_empty
+    end
+  end
+
+  describe '#append' do
+    it 'adds a word to the buffer array' do
+      buffer = my_buffer.buffer
+      expect{
+        my_buffer.append my_word
+      }.to change{ buffer.count }.by 1
+    end
+  end
+
+  describe '#to_s' do
+    context 'with a populated buffer' do
+      before(:each) { my_buffer.append my_word }
+      it 'returns a string' do
+        expect(my_buffer.to_s).to be_an_instance_of String
+      end
+      it 'returns a string of all words in the buffer' do
+        expect(my_buffer.to_s).to eq my_word
+      end
+    end
+
+    context 'with an empty buffer' do
+      it 'raises an EmptyBufferError' do
+        expect{ 
+          my_buffer.to_s
+        }.to raise_error EmptyBufferError
+      end
+    end
+  end
+end

--- a/spec/data-structures/string-buffer/string_spec.rb
+++ b/spec/data-structures/string-buffer/string_spec.rb
@@ -1,0 +1,13 @@
+require_relative '../../spec_helper'
+describe String do
+
+  let(:string_1) { "test" }
+  let(:string_2) { "experiment" }
+  let(:my_words) { [string_1, string_2] }
+  describe '.join_words' do
+    it 'returns a string' do
+      expect(String.join_words my_words).to eq my_words.join("")
+    end
+  end
+
+end


### PR DESCRIPTION
String buffer reduces runtime of concatenating strings.
Creates buffer array to store strings while concatenating.
Once all strings to be joined have been added to the buffer
the program concatenates the characters together once.

Alternatively the program might concatenate the strings for
each word in the array of strings to be joined.

Monkey patched String class to add class method called join_words.

.join_words creates a StringBuffer object and appends all words to
the buffer. Once all words have been appended it call #to_s on
the buffer which concatenates the strings.
