### PR TITLE
String buffer

### DIFF
--- a/lib/data-structures/string-buffer/string.rb
+++ b/lib/data-structures/string-buffer/string.rb
@@ -1,0 +1,12 @@
+require_relative 'string_buffer'
+class String
+
+  def self.join_words words
+    sentence = StringBuffer.new
+    words.each do |word|
+      sentence.append word
+    end
+    sentence.to_s
+  end
+
+end

--- a/lib/data-structures/string-buffer/string_buffer.rb
+++ b/lib/data-structures/string-buffer/string_buffer.rb
@@ -10,7 +10,6 @@ class StringBuffer
   end
 
   def to_s
-    raise EmptyBufferError.new("buffer is empty") if buffer.empty?
     sentence = ""
     buffer.each do |word|
       sentence.concat(word) # or shovel operator <<
@@ -18,5 +17,3 @@ class StringBuffer
     sentence
   end
 end
-
-class EmptyBufferError < StandardError; end

--- a/lib/data-structures/string-buffer/string_buffer.rb
+++ b/lib/data-structures/string-buffer/string_buffer.rb
@@ -1,0 +1,22 @@
+class StringBuffer
+
+  attr_accessor :buffer
+  def initialize
+    @buffer = []
+  end
+
+  def append word
+    buffer.push word
+  end
+
+  def to_s
+    raise EmptyBufferError.new("buffer is empty") if buffer.empty?
+    sentence = ""
+    buffer.each do |word|
+      sentence += word
+    end
+    sentence
+  end
+end
+
+class EmptyBufferError < StandardError; end

--- a/lib/data-structures/string-buffer/string_buffer.rb
+++ b/lib/data-structures/string-buffer/string_buffer.rb
@@ -13,7 +13,7 @@ class StringBuffer
     raise EmptyBufferError.new("buffer is empty") if buffer.empty?
     sentence = ""
     buffer.each do |word|
-      sentence += word
+      sentence.concat(word) # or shovel operator <<
     end
     sentence
   end

--- a/spec/data-structures/string-buffer/string_buffer_spec.rb
+++ b/spec/data-structures/string-buffer/string_buffer_spec.rb
@@ -1,0 +1,44 @@
+require_relative '../../spec_helper'
+describe StringBuffer do
+
+  let(:my_buffer) { StringBuffer.new }
+  let(:my_word) { 'test' }
+  describe '#initialize' do
+    it 'makes a StringBuffer' do
+      expect(my_buffer).to be_an_instance_of StringBuffer
+    end
+
+    it 'creates an empty buffer array' do
+      expect(my_buffer.buffer).to be_empty
+    end
+  end
+
+  describe '#append' do
+    it 'adds a word to the buffer array' do
+      buffer = my_buffer.buffer
+      expect{
+        my_buffer.append my_word
+      }.to change{ buffer.count }.by 1
+    end
+  end
+
+  describe '#to_s' do
+    context 'with a populated buffer' do
+      before(:each) { my_buffer.append my_word }
+      it 'returns a string' do
+        expect(my_buffer.to_s).to be_an_instance_of String
+      end
+      it 'returns a string of all words in the buffer' do
+        expect(my_buffer.to_s).to eq my_word
+      end
+    end
+
+    context 'with an empty buffer' do
+      it 'raises an EmptyBufferError' do
+        expect{ 
+          my_buffer.to_s
+        }.to raise_error EmptyBufferError
+      end
+    end
+  end
+end

--- a/spec/data-structures/string-buffer/string_buffer_spec.rb
+++ b/spec/data-structures/string-buffer/string_buffer_spec.rb
@@ -1,43 +1,34 @@
 require_relative '../../spec_helper'
 describe StringBuffer do
 
-  let(:my_buffer) { StringBuffer.new }
-  let(:my_word) { 'test' }
+  let(:string_buffer) { StringBuffer.new }
+  let(:word) { 'test' }
   describe '#initialize' do
-    it 'makes a StringBuffer' do
-      expect(my_buffer).to be_an_instance_of StringBuffer
-    end
-
     it 'creates an empty buffer array' do
-      expect(my_buffer.buffer).to be_empty
+      expect(string_buffer.buffer).to be_empty
     end
   end
 
   describe '#append' do
     it 'adds a word to the buffer array' do
-      buffer = my_buffer.buffer
+      buffer = string_buffer.buffer
       expect{
-        my_buffer.append my_word
+        string_buffer.append word
       }.to change{ buffer.count }.by 1
     end
   end
 
   describe '#to_s' do
     context 'with a populated buffer' do
-      before(:each) { my_buffer.append my_word }
-      it 'returns a string' do
-        expect(my_buffer.to_s).to be_an_instance_of String
-      end
       it 'returns a string of all words in the buffer' do
-        expect(my_buffer.to_s).to eq my_word
+        string_buffer.append word
+        expect(string_buffer.to_s).to eq word
       end
     end
 
     context 'with an empty buffer' do
       it 'raises an EmptyBufferError' do
-        expect{ 
-          my_buffer.to_s
-        }.to raise_error EmptyBufferError
+        expect(string_buffer.to_s).to be_empty
       end
     end
   end

--- a/spec/data-structures/string-buffer/string_spec.rb
+++ b/spec/data-structures/string-buffer/string_spec.rb
@@ -1,0 +1,13 @@
+require_relative '../../spec_helper'
+describe String do
+
+  let(:string_1) { "test" }
+  let(:string_2) { "experiment" }
+  let(:my_words) { [string_1, string_2] }
+  describe '.join_words' do
+    it 'returns a string' do
+      expect(String.join_words my_words).to eq my_words.join("")
+    end
+  end
+
+end

--- a/spec/data-structures/string-buffer/string_spec.rb
+++ b/spec/data-structures/string-buffer/string_spec.rb
@@ -3,10 +3,10 @@ describe String do
 
   let(:string_1) { "test" }
   let(:string_2) { "experiment" }
-  let(:my_words) { [string_1, string_2] }
+  let(:words) { [string_1, string_2] }
   describe '.join_words' do
     it 'returns a string' do
-      expect(String.join_words my_words).to eq my_words.join("")
+      expect(String.join_words words).to eq words.join("")
     end
   end
 


### PR DESCRIPTION
StringBuffers are used in Java to limit the number of string objects created in memory when concatenating strings.

In Ruby we can use the String#concat or String#<< methods to update strings in place so there is not a need for StringBuffers as far as I can see. It also looks like the StringIO class might serve a similar purpose.

This will add a Ruby implementation of a Java StringBuffer to emulate the behavior.
